### PR TITLE
Add placeholder and autofocus properties for Trix Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Add ability to allow Rails direct uploading via Trix Editor. ([@abhaynikam][])
+* Add options to configure placeholder and autofocus for Trix Editor. ([@abhaynikam][])
 
 ## 1.0.4 (30-March-2020)
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ export default function TrixEditor(props) {
 | ------------------- | ---- | ----------- |
 | toolbarId           | string   | If a custom toolbar is used for the Trix Input, pass the `toolbarId` of the custom toolbar to the input. |
 | isRailsDirectUpload | boolean | React Trix editor support direct uploading of the files to the service if you are using Rails as a backend server. This defaults to `false` |
+| placeholder | string | Adds a placeholder to the React Trix Input |
 | defaultValue        | string   | The default value of the React Trix Input |
 | trixInputRef        | function | Adds a custom ref to the React Trix Input to programmatically edit text. Read the documentation for manual things you can perform on Trix editor [here](https://github.com/basecamp/trix#editing-text-programmatically) |
 | onBeforeInitialize  | function | Fires when the `<trix-editor>` element is attached to the DOM just before Trix installs its editor object. |

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,9 @@ export default function TrixEditor(props) {
 | ------------------- | ---- | ----------- |
 | toolbarId           | string   | If a custom toolbar is used for the Trix Input, pass the `toolbarId` of the custom toolbar to the input. |
 | isRailsDirectUpload | boolean | React Trix editor support direct uploading of the files to the service if you are using Rails as a backend server. This defaults to `false` |
-| placeholder | string | Adds a placeholder to the React Trix Input |
-| defaultValue        | string   | The default value of the React Trix Input |
+| placeholder         | string | Adds a placeholder to the React Trix Input |
+| defaultValue        | string | The default value of the React Trix Input |
+| autofocus           | boolean | Autofocus in the trix input. This is defaults to `false` |
 | trixInputRef        | function | Adds a custom ref to the React Trix Input to programmatically edit text. Read the documentation for manual things you can perform on Trix editor [here](https://github.com/basecamp/trix#editing-text-programmatically) |
 | onBeforeInitialize  | function | Fires when the `<trix-editor>` element is attached to the DOM just before Trix installs its editor object. |
 | onInitialize        | function | Fires when the `<trix-editor>` element is attached to the DOM and its editor object is ready for use. |

--- a/src/components/ReactTrixRTEInput/ReactTrixRTEInput.jsx
+++ b/src/components/ReactTrixRTEInput/ReactTrixRTEInput.jsx
@@ -20,7 +20,8 @@ function ReactTrixRTEInput(props) {
     onBeforeInitialize,
     trixInputRef,
     isRailsDirectUpload = false,
-    placeholder
+    placeholder,
+    autofocus,
   } = props;
   const trixRTEInputRef = trixInputRef ? trixInputRef : useRef();
   const [value, setValue] = useState(defaultValue);
@@ -30,6 +31,8 @@ function ReactTrixRTEInput(props) {
     "data-direct-upload-url": RAILS_DIRECT_UPLOADS_URL,
     "data-blob-url-template": RAILS_SERVICE_BLOB_URL
   } : {};
+  let trixEditorOptions = {}
+  if(autofocus) trixEditorOptions["autofocus"] = true;
 
   useEffect(() => {
     trixRTEInputRef.current.addEventListener("trix-change", handleChange);
@@ -73,11 +76,12 @@ function ReactTrixRTEInput(props) {
         name="content"
       />
       <trix-editor
-        placeholder={placeholder}
         toolbar={toolbarId}
+        placeholder={placeholder}
         ref={trixRTEInputRef}
         input={trixRTEInputId}
         {...directUploadOptions}
+        {...trixEditorOptions}
       />
     </Fragment>
   );
@@ -97,7 +101,8 @@ ReactTrixRTEInput.propTypes = {
   onBeforeInitialize: PropTypes.func,
   trixInputRef: PropTypes.func,
   isRailsDirectUpload: PropTypes.bool,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  autofocus: PropTypes.bool,
 };
 
 export default ReactTrixRTEInput;

--- a/src/components/ReactTrixRTEInput/ReactTrixRTEInput.jsx
+++ b/src/components/ReactTrixRTEInput/ReactTrixRTEInput.jsx
@@ -19,7 +19,8 @@ function ReactTrixRTEInput(props) {
     onSelectionChange,
     onBeforeInitialize,
     trixInputRef,
-    isRailsDirectUpload = false
+    isRailsDirectUpload = false,
+    placeholder
   } = props;
   const trixRTEInputRef = trixInputRef ? trixInputRef : useRef();
   const [value, setValue] = useState(defaultValue);
@@ -72,6 +73,7 @@ function ReactTrixRTEInput(props) {
         name="content"
       />
       <trix-editor
+        placeholder={placeholder}
         toolbar={toolbarId}
         ref={trixRTEInputRef}
         input={trixRTEInputId}
@@ -95,6 +97,7 @@ ReactTrixRTEInput.propTypes = {
   onBeforeInitialize: PropTypes.func,
   trixInputRef: PropTypes.func,
   isRailsDirectUpload: PropTypes.bool,
+  placeholder: PropTypes.string
 };
 
 export default ReactTrixRTEInput;

--- a/src/components/ReactTrixRTEInput/ReactTrixRTEInput.test.js
+++ b/src/components/ReactTrixRTEInput/ReactTrixRTEInput.test.js
@@ -24,4 +24,12 @@ describe('ReactTrixRTEInput', () => {
     expect(wrapper.find('trix-editor').props()['data-direct-upload-url']).toEqual(RAILS_DIRECT_UPLOADS_URL);
     expect(wrapper.find('trix-editor').props()['data-blob-url-template']).toEqual(RAILS_SERVICE_BLOB_URL);
   });
+
+  it('renders with placeholder', () => {
+    const wrapper = shallow(<ReactTrixRTEInput placeholder="Enter the description" />);
+    expect(wrapper.find('trix-editor').props().placeholder).toEqual("Enter the description");
+
+    const withoutPlaceholderWrapper = shallow(<ReactTrixRTEInput />);
+    expect(withoutPlaceholderWrapper.find('trix-editor').props().placeholder).toEqual(undefined);
+  });
 });

--- a/src/components/ReactTrixRTEInput/ReactTrixRTEInput.test.js
+++ b/src/components/ReactTrixRTEInput/ReactTrixRTEInput.test.js
@@ -32,4 +32,9 @@ describe('ReactTrixRTEInput', () => {
     const withoutPlaceholderWrapper = shallow(<ReactTrixRTEInput />);
     expect(withoutPlaceholderWrapper.find('trix-editor').props().placeholder).toEqual(undefined);
   });
+
+  it('renders with autofocus', () => {
+    const wrapper = shallow(<ReactTrixRTEInput autofocus />);
+    expect(wrapper.find('trix-editor').props().autofocus).toEqual(true);
+  });
 });

--- a/stories/0-ReactTrixInputRTE.stories.js
+++ b/stories/0-ReactTrixInputRTE.stories.js
@@ -74,3 +74,7 @@ export const WithAttachmentRemove = () => (
 export const WithIsRailsDirectUpload = () => (
   <ReactTrixRTEInput isRailsDirectUpload />
 );
+
+export const WithPlaceholder = () => (
+  <ReactTrixRTEInput placeholder="Enter the description" />
+);

--- a/stories/0-ReactTrixInputRTE.stories.js
+++ b/stories/0-ReactTrixInputRTE.stories.js
@@ -78,3 +78,7 @@ export const WithIsRailsDirectUpload = () => (
 export const WithPlaceholder = () => (
   <ReactTrixRTEInput placeholder="Enter the description" />
 );
+
+export const WithAutoFocus = () => (
+  <ReactTrixRTEInput autofocus />
+);

--- a/stories/1-ReactTrixWithCustomToolbar.stories.js
+++ b/stories/1-ReactTrixWithCustomToolbar.stories.js
@@ -49,3 +49,10 @@ export const WithRailsDirectUpload = () => (
     <ReactTrixRTEInput toolbarId="react-trix-rte-editor" isRailsDirectUpload />
   </Fragment>
 );
+
+export const WithPlaceholder = () => (
+  <Fragment>
+    <ReactTrixRTEToolbar toolbarId="react-trix-rte-editor" />
+    <ReactTrixRTEInput toolbarId="react-trix-rte-editor" placeholder="Enter your text." />
+  </Fragment>
+);

--- a/stories/1-ReactTrixWithCustomToolbar.stories.js
+++ b/stories/1-ReactTrixWithCustomToolbar.stories.js
@@ -56,3 +56,10 @@ export const WithPlaceholder = () => (
     <ReactTrixRTEInput toolbarId="react-trix-rte-editor" placeholder="Enter your text." />
   </Fragment>
 );
+
+export const WithAutoFocus = () => (
+  <Fragment>
+    <ReactTrixRTEToolbar toolbarId="react-trix-rte-editor" />
+    <ReactTrixRTEInput toolbarId="react-trix-rte-editor" autofocus />
+  </Fragment>
+);


### PR DESCRIPTION
fixes #4 

This PR adds options to configure the `placeholder` and `autofocus` properties on Trix Editor 