### PR TITLE
Crash fix when using ReactTrixRTEToolbar with toolbarActions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "1.0.9",
   "description": "React wrapper for Trix rich text editor created by Basecamp",
   "main": "./index.js",
-  "peerDependencies": {
-    "react": "^16.13.1",
-    "trix": "^1.2.3"
-  },
   "scripts": {
     "build": "webpack --config webpack.config.babel.js",
     "build-examples": "webpack --config examples/webpack.config.babel.js --progress",


### PR DESCRIPTION
removed redundant peerDependency.

Lib throws when using `ReactTrixRTEToolbar` with `toolbarActions` prop because it dosen't have `ramda` in dependencies.