### PR TITLE
Add random salt to getUniqInputId

### DIFF
--- a/src/components/Shared/utils.js
+++ b/src/components/Shared/utils.js
@@ -8,6 +8,7 @@ export const groupBy = (collection, prop) => {
 }
 
 export const getUniqInputId = (prefix = 'react-trix-rte-input-') => {
-  const uniqueDateTimestamp = new Date().getTime();
-  return `${prefix}${uniqueDateTimestamp}`
+  const dateTimestamp = new Date().getTime();
+  const randomSalt = Math.random().toFixed(9).slice(2)
+  return `${prefix}${dateTimestamp}-${randomSalt}`
 }


### PR DESCRIPTION
Closes #39 

Adds a random salt to getUniqInputId. Still not entirely unique, but collisions should happen only once in a billion times this method is run in the same millisecond.

Please let me know if you have any ideas for improvements!